### PR TITLE
Featured prompt selection happens at data init

### DIFF
--- a/HackDays/BookCard.swift
+++ b/HackDays/BookCard.swift
@@ -30,7 +30,7 @@ struct BookCard: View {
         self.book = book
         self.onClick = onClick
         self.onRemove = onRemove
-        self.randomPrompt = book.prompts.randomElement()!
+        self.randomPrompt = book.prompts[book.featuredPromptIdx]
     }
     
     private func getGesturePercentage(_ geometry: GeometryProxy, from gesture: DragGesture.Value) -> CGFloat {

--- a/HackDays/Models/Book.swift
+++ b/HackDays/Models/Book.swift
@@ -16,4 +16,5 @@ struct Book {
     var category: String
     var imageURL: String
     var prompts: Array<Prompt>
+    var featuredPromptIdx: Int
 }

--- a/HackDays/ViewModels/BookViewModel.swift
+++ b/HackDays/ViewModels/BookViewModel.swift
@@ -41,7 +41,8 @@ class BookViewModel: ObservableObject{
                            answer: "Celestial beings from the other side of the tracks"),
                     Prompt(question: "I know the best spot in town for…",
                            answer: "Escaping from reality / creating our own"),
-                ]),
+                ],
+                featuredPromptIdx: 1),
             Book(
                 id: "1",
                 author: "Ben McKenzie",
@@ -56,7 +57,8 @@ class BookViewModel: ObservableObject{
                            answer: "My author was in The OC, Smallville, and Gotham"),
                     Prompt(question: "I know the best spot in town for...",
                            answer: "Having an interview with Sam Bankman-Fried"),
-                ]),
+                ],
+                featuredPromptIdx: 1),
             Book(
                 id: "2",
                 author: "Gus Moreno",
@@ -70,21 +72,25 @@ class BookViewModel: ObservableObject{
                     Prompt(question: "I’m weirdly attracted to…",
                            answer: "Demonic entities (or at least they’re attracted to me)."),
                     Prompt(question: "The one thing I’d like to know about you is…",
-                           answer: "If you are still alive.")]),
-                Book(
-                    id: "3",
-                    author: "Jennette McCurdy",
-                    title: "I'm Glad My Mom Died",
-                    pageCount: "314",
-                    category: "Memoir",
-                    imageURL: "https://res.cloudinary.com/bookbub/image/upload/t_ci_ar_6:9_padded,f_auto,q_auto,dpr_2,c_scale,w_405/v1689632693/pro_pbid_4948915.jpg",
-                    prompts: [
-                        Prompt(question: "You should leave a comment if…",
-                               answer: "You have childhood trauma!"),
-                        Prompt(question: "My simple pleasures…",
-                               answer: "Are funerals and a good joke."),
-                        Prompt(question: "Green flags I look for…",
-                               answer: "You go to therapy and do not think you are the second coming of Christ."),])
-                ]
+                           answer: "If you are still alive.")
+                ],
+                featuredPromptIdx: 1),
+            Book(
+                id: "3",
+                author: "Jennette McCurdy",
+                title: "I'm Glad My Mom Died",
+                pageCount: "314",
+                category: "Memoir",
+                imageURL: "https://res.cloudinary.com/bookbub/image/upload/t_ci_ar_6:9_padded,f_auto,q_auto,dpr_2,c_scale,w_405/v1689632693/pro_pbid_4948915.jpg",
+                prompts: [
+                    Prompt(question: "You should leave a comment if…",
+                           answer: "You have childhood trauma!"),
+                    Prompt(question: "My simple pleasures…",
+                           answer: "Are funerals and a good joke."),
+                    Prompt(question: "Green flags I look for…",
+                           answer: "You go to therapy and do not think you are the second coming of Christ.")
+                ],
+                featuredPromptIdx: 1),
+            ]
     }
 }

--- a/HackDays/ViewModels/BookViewModel.swift
+++ b/HackDays/ViewModels/BookViewModel.swift
@@ -42,7 +42,7 @@ class BookViewModel: ObservableObject{
                     Prompt(question: "I know the best spot in town for…",
                            answer: "Escaping from reality / creating our own"),
                 ],
-                featuredPromptIdx: 1),
+                featuredPromptIdx: Int.random(in: 0...2)),
             Book(
                 id: "1",
                 author: "Ben McKenzie",
@@ -58,7 +58,7 @@ class BookViewModel: ObservableObject{
                     Prompt(question: "I know the best spot in town for...",
                            answer: "Having an interview with Sam Bankman-Fried"),
                 ],
-                featuredPromptIdx: 1),
+                featuredPromptIdx: Int.random(in: 0...2)),
             Book(
                 id: "2",
                 author: "Gus Moreno",
@@ -74,7 +74,7 @@ class BookViewModel: ObservableObject{
                     Prompt(question: "The one thing I’d like to know about you is…",
                            answer: "If you are still alive.")
                 ],
-                featuredPromptIdx: 1),
+                featuredPromptIdx: Int.random(in: 0...2)),
             Book(
                 id: "3",
                 author: "Jennette McCurdy",
@@ -90,7 +90,7 @@ class BookViewModel: ObservableObject{
                     Prompt(question: "Green flags I look for…",
                            answer: "You go to therapy and do not think you are the second coming of Christ.")
                 ],
-                featuredPromptIdx: 1),
+                featuredPromptIdx: Int.random(in: 0...2)),
             ]
     }
 }


### PR DESCRIPTION
Because we modify the published BookViewModel on swipe, we are rerendering the SwipeableView and BookCard in a way that causes us to re-randomized our prompt selection each time we swipe.

This change just sets a `featuredPromptIdx` when we create the data, which keeps it the same on each swipe